### PR TITLE
Allow Parsing of netrc with Unknown Entries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,13 @@ pub enum Error {
 pub type Result<A> = std::result::Result<A, Error>;
 
 pub struct Parser {
-  ignore_unknown_entries: bool
+  pub ignore_unknown_entries: bool
+}
+
+impl Default for Parser {
+    fn default() -> Self {
+        return Parser{ignore_unknown_entries: false};
+    }
 }
 
 impl Parser {
@@ -139,7 +145,7 @@ impl Netrc {
     /// let netrc = Netrc::parse(input).unwrap();
     /// ```
     pub fn parse<A: BufRead>(buf: A) -> Result<Netrc> {
-      let parser = Parser{ignore_unknown_entries: false};
+      let parser = Parser::default();
       return parser.parse(buf);
     }
 }


### PR DESCRIPTION
First, thanks for publishing this crate. I ran into a problem when using it in a project, and here's my proposed solution which you're welcome to use.

---

The problem is this; when using Heroku with 2FA, it adds a `method interactive` entry, like so:

```
machine api.heroku.com
  login example@example.com
  password af7edbc6-af77-11e8-bf1e-8f1e590fbef2
  method interactive
```

With the current implementation the parsing returns `Error::Parse("Unknown entry `method'")`. In my project which uses `netrc-rs` I was happy to just ignore these entries as they weren't needed.

---

My proposed solution was to introduce a configurable `Parser` struct, which allows whether or not to return an error or not for an unknown entry. The `parse` and `parse_entry` methods are moved to `Parser` and the signature of `parse_entry` is changed to take both a reference to the parser, and an instantiated `Netrc` to be populated.

`Netrc::parse` then becomes a convenience method which parses using the default Parser. This default parser is set not to ignore unknown entries to match the existing behaviour and keep backwards compatibility.

If this seems like a reasonable approach, I can add some documentation around this new approach. If you're not keen on it, and if you'd prefer to solve it in a different way then I can potentially work on implementing it that way.
